### PR TITLE
added tab-pageview for html table of game history information

### DIFF
--- a/src/data_table.html
+++ b/src/data_table.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+  <head>
+    <style>
+      table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+      th,
+      td {
+        border: 1px solid black;
+        padding: 8px;
+        text-align: left;
+      }
+      th {
+        background-color: #f2f2f2;
+      }
+      a {
+        display: block;
+        margin-bottom: 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="a4f4m4kl">
+      <img
+        id="profilelnk"
+        src="user.png"
+        width="20px"
+        height="20px"
+        style="cursor: pointer"
+      />
+    </div>
+    <table id="lichessTable">
+      <thead>
+        <tr>
+          <th>Game Date</th>
+          <th>Lichess GameIds</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
+    <script src="data_table.js" type="module"></script>
+  </body>
+</html>

--- a/src/data_table.js
+++ b/src/data_table.js
@@ -1,0 +1,45 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const tableBody = document
+    .getElementById("lichessTable")
+    .querySelector("tbody");
+
+  let skeystor = [];
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    let g = key.substring(0, key.length - 8);
+    let b = new Date(g);
+    if (b.toString() == "Invalid Date") continue;
+
+    if (key.includes("lichess")) {
+      const data = JSON.parse(localStorage.getItem(key));
+
+      if (Array.isArray(data)) {
+        skeystor.push([g, data]);
+      }
+    }
+  }
+  skeystor.sort((a, b) => new Date(a[0]) - new Date(b[0]));
+  skeystor.forEach((key) => {
+    const row = document.createElement("tr");
+    const keyCell = document.createElement("td");
+    keyCell.textContent = key[0];
+    row.appendChild(keyCell);
+    const dataCell = document.createElement("td");
+    let data = key[1];
+    data.forEach((item) => {
+      const link = document.createElement("a");
+      link.href = "https://lichess.org/" + item;
+      link.textContent = item;
+      dataCell.appendChild(link);
+    });
+    row.appendChild(dataCell);
+
+    tableBody.appendChild(row);
+  });
+});
+
+var profiletoggle = document.getElementById("profilelnk");
+profiletoggle.addEventListener("click", function () {
+  chrome.runtime.sendMessage({ action: "open_main" });
+});

--- a/src/extension.js
+++ b/src/extension.js
@@ -361,7 +361,6 @@ document
               }
               document.getElementById("profile-howto").style.maxWidth = "16rem";
 
-              // Save data to localStorage
               const userData = { user: inputValue, img: selectedUrl };
               localStorage.setItem("chesshelper", JSON.stringify(userData));
             }
@@ -464,4 +463,26 @@ flipboardelem.addEventListener("change", function () {
     myToggle.checked = false;
     bv = "lichess";
   }
+});
+
+for (let i = 0; i < localStorage.length; i++) {
+  const key = localStorage.key(i);
+  let g = key.substring(0, key.length - 8);
+  let b = new Date(g);
+  if (b.toString() == "Invalid Date") continue;
+
+  if (key.includes("lichess")) {
+    const data = JSON.parse(localStorage.getItem(key));
+
+    if (Array.isArray(data)) {
+      let chli = document.getElementById("dtopt");
+      chli.style.display = "list-item";
+      break;
+    }
+  }
+}
+
+var opendata = document.getElementById("datatable");
+opendata.addEventListener("click", function () {
+  chrome.runtime.sendMessage({ action: "open_table" });
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "chess helper",
-  "version": "1.6",
+  "version": "1.7",
   "description": "Assistant for chess.com and lichess.",
   "minimum_chrome_version": "114",
   "background": {

--- a/src/page.html
+++ b/src/page.html
@@ -92,7 +92,8 @@
         display: flex;
       }
 
-      #supportlink {
+      #supportlink,
+      #datatable {
         text-decoration: underline;
         cursor: pointer;
       }
@@ -270,6 +271,9 @@
           </li>
           <li>
             <p id="supportlink">Support this Creator</p>
+          </li>
+          <li style="display: none" id="dtopt">
+            <p id="datatable">Game History</p>
           </li>
         </ul>
 

--- a/src/script.js
+++ b/src/script.js
@@ -220,7 +220,7 @@ toggleboard.addEventListener("change", function () {
   }
 });
 
-var profiletoggle = document.getElementById("profilelnk");
+let profiletoggle = document.getElementById("profilelnk");
 profiletoggle.addEventListener("click", function () {
   chrome.runtime.sendMessage({ action: "open_main" });
 });

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -26,6 +26,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "open_main") {
     chrome.tabs.create({ url: "page.html" });
   }
+  if (message.action === "open_table") {
+    chrome.tabs.create({ url: "data_table.html" });
+  }
   (async () => {
     if (message.type === "open_side_panel") {
       await chrome.sidePanel.open({ tabId: sender.tab.id });


### PR DESCRIPTION
LocalStorage saves gameid's from lichess, that the user has requested engine assistance on. A link on the extension homepage called "Game History" will now open a chrome tab with an html table that is a representation of the data from local storage. The user can see the date and ids of games they have played with the extension as a helper.